### PR TITLE
point 동시성 문제 해결 시도. 해결X

### DIFF
--- a/src/main/java/hhplus/ticketing/api/payment/facade/PaymentFacade.java
+++ b/src/main/java/hhplus/ticketing/api/payment/facade/PaymentFacade.java
@@ -42,11 +42,3 @@ public class PaymentFacade {
             return paymentTransaction;
         }
     }
-//
-//Ticket
-//long id;
-//Seat seat;
-//long userId;
-//long price;
-//TicketStatus status;
-//LocalDateTime reservedTime;

--- a/src/main/java/hhplus/ticketing/api/point/facade/PointFacade.java
+++ b/src/main/java/hhplus/ticketing/api/point/facade/PointFacade.java
@@ -1,5 +1,6 @@
 package hhplus.ticketing.api.point.facade;
 
+import hhplus.ticketing.base.redisson.DistributedLock;
 import hhplus.ticketing.domain.point.components.PointService;
 import hhplus.ticketing.domain.point.models.Point;
 import hhplus.ticketing.domain.user.components.UserService;
@@ -18,7 +19,7 @@ public class PointFacade {
     @Autowired
     private final UserService userService;
 
-    @DistributedLock(key="#userId")
+    @DistributedLock(key="pointlock-user#userId")
     public void transact(long userId, Point point) {
         pointService.recordPointTransaction(userId, point, LocalDateTime.now());
         userService.updateBalance(userId, point);

--- a/src/main/java/hhplus/ticketing/base/redisson/AopForTransaction.java
+++ b/src/main/java/hhplus/ticketing/base/redisson/AopForTransaction.java
@@ -1,4 +1,4 @@
-package hhplus.ticketing.point.integration;
+package hhplus.ticketing.base.redisson;
 
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.springframework.stereotype.Component;

--- a/src/main/java/hhplus/ticketing/base/redisson/CustomSpringELParser.java
+++ b/src/main/java/hhplus/ticketing/base/redisson/CustomSpringELParser.java
@@ -1,4 +1,4 @@
-package hhplus.ticketing.point.integration;
+package hhplus.ticketing.base.redisson;
 
 import org.springframework.expression.ExpressionParser;
 import org.springframework.expression.spel.standard.SpelExpressionParser;

--- a/src/main/java/hhplus/ticketing/base/redisson/DistributedLock.java
+++ b/src/main/java/hhplus/ticketing/base/redisson/DistributedLock.java
@@ -1,4 +1,4 @@
-package hhplus.ticketing.api.point.facade;
+package hhplus.ticketing.base.redisson;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/hhplus/ticketing/base/redisson/DistributedLockAop.java
+++ b/src/main/java/hhplus/ticketing/base/redisson/DistributedLockAop.java
@@ -1,7 +1,5 @@
-package hhplus.ticketing.point.integration;
+package hhplus.ticketing.base.redisson;
 
-import hhplus.ticketing.api.point.facade.DistributedLock;
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
@@ -34,12 +32,21 @@ public class DistributedLockAop {
         try{
             boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
             if (!available) {
-                throw new InterruptedException();
+                return false;
             }
             return aopForTransaction.proceed(joinPoint);
-        } finally {
-            rLock.unlock();
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        }finally {
+            try{
+                rLock.unlock();
+            } catch (IllegalMonitorStateException e){
+                throw new IllegalArgumentException();
+            }
+
         }
     }
+
+
 }
 

--- a/src/main/java/hhplus/ticketing/domain/point/components/PointService.java
+++ b/src/main/java/hhplus/ticketing/domain/point/components/PointService.java
@@ -21,7 +21,6 @@ public class PointService {
 
     public PointTransaction recordPointTransaction(long userId, Point point, LocalDateTime time) {
         PointTransaction pointTransaction = new PointTransaction(userId, time, point.getAmount(), point.getType());
-
         return pointRepository.savePointTransaction(pointTransaction);
     }
 

--- a/src/main/java/hhplus/ticketing/domain/point/infra/MemoryPointRepository.java
+++ b/src/main/java/hhplus/ticketing/domain/point/infra/MemoryPointRepository.java
@@ -14,7 +14,7 @@ public class MemoryPointRepository implements PointRepository {
 
 
     public PointTransaction savePointTransaction(PointTransaction pointTransaction) {
-        List<PointTransaction> transactionHistory = pointHistoryMap.get(pointTransaction.userId());
+        List<PointTransaction> transactionHistory = pointHistoryMap.get(pointTransaction.getUserId());
         transactionHistory.add(pointTransaction);
         return pointTransaction;
 

--- a/src/main/java/hhplus/ticketing/domain/point/infra/PointTransactionEntity.java
+++ b/src/main/java/hhplus/ticketing/domain/point/infra/PointTransactionEntity.java
@@ -30,10 +30,10 @@ public class PointTransactionEntity {
 
     public static PointTransactionEntity from(PointTransaction pointTransaction) {
         return PointTransactionEntity.builder()
-                .userId(pointTransaction.userId())
-                .transactionTime(pointTransaction.transactionTime())
-                .amount(pointTransaction.amount())
-                .type(pointTransaction.type())
+                .userId(pointTransaction.getUserId())
+                .transactionTime(pointTransaction.getTransactionTime())
+                .amount(pointTransaction.getAmount())
+                .type(pointTransaction.getType())
                 .build();
     }
 

--- a/src/main/java/hhplus/ticketing/domain/point/models/PointTransaction.java
+++ b/src/main/java/hhplus/ticketing/domain/point/models/PointTransaction.java
@@ -1,19 +1,41 @@
 package hhplus.ticketing.domain.point.models;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+//@Builder
+//public record PointTransaction(
+//        long id,
+//        long userId,
+//        LocalDateTime transactionTime,
+//        long amount,
+//        PointType type
+//) {
+//
+//    public PointTransaction(long userId, LocalDateTime transactionTime, long amount, PointType type) {
+//        //TODO: possible danger-DB에서 id값이 업데이트되긴 하지만, 도메인모델에서 id를 0으로 전부 설정하는 것이 안전한 방법은 아니다.
+//        this(0, userId, transactionTime, amount, type);
+//    }
+//}
+
 @Builder
-public record PointTransaction(
-        long id,
-        long userId,
-        LocalDateTime transactionTime,
-        long amount,
-        PointType type
-) {
+@AllArgsConstructor
+@Getter
+public class PointTransaction {
+    long id;
+    long userId;
+    LocalDateTime transactionTime;
+    long amount;
+    PointType type;
+
+
     public PointTransaction(long userId, LocalDateTime transactionTime, long amount, PointType type) {
-        //TODO: possible danger-DB에서 id값이 업데이트되긴 하지만, 도메인모델에서 id를 0으로 전부 설정하는 것이 안전한 방법은 아니다.
-        this(0, userId, transactionTime, amount, type);
+        this.userId = userId;
+        this.transactionTime = transactionTime;
+        this.amount = amount;
+        this.type = type;
     }
 }

--- a/src/main/java/hhplus/ticketing/domain/ticket/components/TicketService.java
+++ b/src/main/java/hhplus/ticketing/domain/ticket/components/TicketService.java
@@ -1,6 +1,6 @@
 package hhplus.ticketing.domain.ticket.components;
 
-import hhplus.ticketing.api.point.facade.DistributedLock;
+import hhplus.ticketing.base.redisson.DistributedLock;
 import hhplus.ticketing.base.exceptions.UnavailableSeatException;
 import hhplus.ticketing.domain.concert.models.SeatStatus;
 import hhplus.ticketing.domain.ticket.models.Ticket;

--- a/src/main/java/hhplus/ticketing/domain/user/components/UserService.java
+++ b/src/main/java/hhplus/ticketing/domain/user/components/UserService.java
@@ -6,6 +6,7 @@ import hhplus.ticketing.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -25,8 +26,10 @@ public class UserService {
 
     public User updateBalance(long userId, Point point){
         User user = userRepository.findById(userId);
+        System.out.println("before update: user "+user.getId() + " update point " + user.getBalance());
         user.updatePoint(point);
         userRepository.save(user);
+        System.out.println("after update: user "+user.getId() + " update point " + user.getBalance());
         return user;
     }
 

--- a/src/test/java/hhplus/ticketing/point/integration/PointFacadeTest.java
+++ b/src/test/java/hhplus/ticketing/point/integration/PointFacadeTest.java
@@ -120,6 +120,6 @@ public class PointFacadeTest {
 
         List<PointTransaction> pointTransactionList = pointService.queryTransactions(userId);
         assertThat(pointTransactionList).hasSize(2);
-        assertThat(pointTransactionList.get(0).amount()).isEqualTo(rechargePoint.getAmount());
+        assertThat(pointTransactionList.get(0).getAmount()).isEqualTo(rechargePoint.getAmount());
     }
 }

--- a/src/test/java/hhplus/ticketing/point/integration/PointTransactionConcurrencyTest.java
+++ b/src/test/java/hhplus/ticketing/point/integration/PointTransactionConcurrencyTest.java
@@ -48,7 +48,7 @@ class PointTransactionConcurrencyTest {
 
 
     @Test
-    @Disabled
+//    @Disabled
     @DisplayName("포인트가 동시에 처리되는 경우를 확인한다.")
     void concurrent_request_handled_by_order() throws InterruptedException {
         User user = new User(1, 0);
@@ -72,7 +72,7 @@ class PointTransactionConcurrencyTest {
 
         List<PointTransaction> pointTransactionList = pointService.queryTransactions(user.getId());
         for (PointTransaction p: pointTransactionList) {
-            System.out.println("transaction id: " + p.id() + "\namount: " + p.amount() + "\ntime: " + p.transactionTime());
+            System.out.println("transaction id: " + p.getId() + "\namount: " + p.getAmount() + "\ntime: " + p.getTransactionTime());
         }
 
         assertThat(userFound.getBalance()).isEqualTo(100 * numThreads);
@@ -89,6 +89,9 @@ class PointTransactionConcurrencyTest {
         Point point1 = new Point(1000, PointType.RECHARGE);
         userService.updateBalance(user.getId(), point1);
 
+        User foundUser = userService.findById(user.getId());
+
+        assertThat(foundUser.getBalance()).isEqualTo(1000);
 
     }
 }

--- a/src/test/java/hhplus/ticketing/point/integration/PointTransactionJPAIntegrationTest.java
+++ b/src/test/java/hhplus/ticketing/point/integration/PointTransactionJPAIntegrationTest.java
@@ -119,7 +119,7 @@ class PointTransactionJPAIntegrationTest {
 
         List<PointTransaction> pointTransactionList = pointService.queryTransactions(userId);
         assertThat(pointTransactionList).hasSize(2);
-        assertThat(pointTransactionList.get(0).amount()).isEqualTo(rechargePoint.getAmount());
+        assertThat(pointTransactionList.get(0).getAmount()).isEqualTo(rechargePoint.getAmount());
     }
 
 }

--- a/src/test/java/hhplus/ticketing/ticket/integration/TicketConcurrencyTest.java
+++ b/src/test/java/hhplus/ticketing/ticket/integration/TicketConcurrencyTest.java
@@ -57,7 +57,6 @@ public class TicketConcurrencyTest {
             executorService.execute(() ->{
                 try{
                     ticketService.register(1, 10000, seat, LocalDateTime.now());
-//                    ticketFacade.register(1, 1000, 1,  showTime, 2, LocalDateTime.now());
                     successCnt.getAndIncrement();
                 } catch (Exception e) {
                     failCnt.getAndIncrement();


### PR DESCRIPTION
포인트 동시성 문제: 포인트를 동시에 여러번 요청하면 순서대로 처리된다. 유저의 잔액은 순서에 맞게 업데이트된다.  
  
- 포인트충전시: PointService(포인트 내역 생성)+ UserService(사용자 잔액 업데이트)

- Redisson 분산락 적용 후에도 동시성 문제가 해결되지 않았음.
- 문제파악해보니, `PointTransaction`의 생성자의 primary key가 계속 0으로 설정되어있어서 생긴 문제가 있었음.
- Transaction중 포인트 내역 생성에 실패하니, 트랜잭션 자체가 롤백되는 문제였음.

- 해당 문제는 해결했지만, 포인트 동시성 문제는 **여전히** 남아있음.
- 문제 파악해보니, RedissonLock을 획득 후, 트랜잭션을 시작해야하는데, 획득없이도 트랜잭션 액세스가 가능함.
    - 근거
        - `잔액 업데이트`: userRepo(유저 조회) -> user 잔액 업데이트 -> userRepo(유저 저장)
        - `잔액 업데이트 ` 코드에 로그를 찍어보았는데,
        - 만약 RedissonLock으로 잠금이 걸려있다면,
            - 1st request: {userRepo(유저 조회) -> user 잔액 업데이트 -> userRepo(유저 저장)}
            - 2nd request: {userRepo(유저 조회) -> user 잔액 업데이트 -> userRepo(유저 저장)}
            - 3rd request: {userRepo(유저 조회) -> user 잔액 업데이트 -> userRepo(유저 저장)}
            이런식으로 나와야되는데,
            - 유저 조회1, 유저 조회2, ..., user 잔액 업데이트1,  user 잔액 업데이트2, ..., 
            이런식으로 요청 처리가 동시에 처리되는 것을 확인함.

